### PR TITLE
feat: harvest metrics for the current partition lag & status

### DIFF
--- a/burrow_exporter/client.go
+++ b/burrow_exporter/client.go
@@ -75,6 +75,7 @@ type Partition struct {
 	Status    string `json:"status"`
 	Start     Offset `json:"start"`
 	End       Offset `json:"end"`
+	Lag       int64  `json:"current_lag"`
 }
 
 type ConsumerGroupStatusResp struct {

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -32,18 +32,21 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 	}
 
 	for _, partition := range status.Status.Partitions {
+
 		KafkaConsumerPartitionLag.With(prometheus.Labels{
 			"cluster":   status.Status.Cluster,
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
+			"status":    partition.Status,
 		}).Set(float64(partition.Lag))
 
-		KafkaConsumerLastOffsetPartitionLag.With(prometheus.Labels{
+		KafkaConsumerPartitionLastOffsetLag.With(prometheus.Labels{
 			"cluster":   status.Status.Cluster,
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
+			"status":    partition.Status,
 		}).Set(float64(partition.End.Lag))
 
 		KafkaConsumerPartitionCurrentOffset.With(prometheus.Labels{

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -37,6 +37,13 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
+		}).Set(float64(partition.Lag))
+
+		KafkaConsumerLastOffsetPartitionLag.With(prometheus.Labels{
+			"cluster":   status.Status.Cluster,
+			"group":     status.Status.Group,
+			"topic":     partition.Topic,
+			"partition": strconv.Itoa(int(partition.Partition)),
 		}).Set(float64(partition.End.Lag))
 
 		KafkaConsumerPartitionCurrentOffset.With(prometheus.Labels{

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -54,6 +54,7 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
+			"status":    partition.Status,
 		}).Set(float64(partition.End.Offset))
 
 		KafkaConsumerPartitionMaxOffset.With(prometheus.Labels{
@@ -61,6 +62,7 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
+			"status":    partition.Status,
 		}).Set(float64(partition.End.MaxOffset))
 	}
 

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -38,7 +38,6 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
-			"status":    partition.Status,
 		}).Set(float64(partition.Lag))
 
 		KafkaConsumerPartitionLastOffsetLag.With(prometheus.Labels{
@@ -46,7 +45,6 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
-			"status":    partition.Status,
 		}).Set(float64(partition.End.Lag))
 
 		KafkaConsumerPartitionCurrentOffset.With(prometheus.Labels{
@@ -54,7 +52,6 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
-			"status":    partition.Status,
 		}).Set(float64(partition.End.Offset))
 
 		KafkaConsumerPartitionMaxOffset.With(prometheus.Labels{
@@ -62,7 +59,6 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"group":     status.Status.Group,
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
-			"status":    partition.Status,
 		}).Set(float64(partition.End.MaxOffset))
 	}
 

--- a/burrow_exporter/exporter.go
+++ b/burrow_exporter/exporter.go
@@ -22,6 +22,8 @@ type BurrowExporter struct {
 	wg                sync.WaitGroup
 }
 
+var partitionStatuses = [...]string{"OK", "WARNING", "STALL", "STOP", "ERROR"}
+
 func (be *BurrowExporter) processGroup(cluster, group string) {
 	status, err := be.client.ConsumerGroupLag(cluster, group)
 	if err != nil {
@@ -60,6 +62,20 @@ func (be *BurrowExporter) processGroup(cluster, group string) {
 			"topic":     partition.Topic,
 			"partition": strconv.Itoa(int(partition.Partition)),
 		}).Set(float64(partition.End.MaxOffset))
+
+		for _, partitionStatus := range partitionStatuses {
+			active := 0
+			if partitionStatus == partition.Status {
+				active = 1
+			}
+			KafkaConsumerPartitionStatus.With(prometheus.Labels{
+				"cluster":   status.Status.Cluster,
+				"group":     status.Status.Group,
+				"topic":     partition.Topic,
+				"partition": strconv.Itoa(int(partition.Partition)),
+				"status":    partitionStatus,
+			}).Set(float64(active))
+		}
 	}
 
 	KafkaConsumerTotalLag.With(prometheus.Labels{

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -6,6 +6,13 @@ var (
 	KafkaConsumerPartitionLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_lag",
+			Help: "The lag of the consumer on a partition as reported by burrow.",
+		},
+		[]string{"cluster", "group", "topic", "partition"},
+	)
+	KafkaConsumerLastOffsetPartitionLag = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_last_offset_lag",
 			Help: "The lag of the latest offset commit on a partition as reported by burrow.",
 		},
 		[]string{"cluster", "group", "topic", "partition"},
@@ -42,6 +49,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionLag)
+	prometheus.MustRegister(KafkaConsumerLastOffsetPartitionLag)
 	prometheus.MustRegister(KafkaConsumerPartitionCurrentOffset)
 	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -8,14 +8,14 @@ var (
 			Name: "kafka_burrow_partition_lag",
 			Help: "The lag of the consumer on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "status"},
 	)
-	KafkaConsumerLastOffsetPartitionLag = prometheus.NewGaugeVec(
+	KafkaConsumerPartitionLastOffsetLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_last_offset_lag",
 			Help: "The lag of the latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "status"},
 	)
 	KafkaConsumerPartitionCurrentOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -49,7 +49,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(KafkaConsumerPartitionLag)
-	prometheus.MustRegister(KafkaConsumerLastOffsetPartitionLag)
+	prometheus.MustRegister(KafkaConsumerPartitionLastOffsetLag)
 	prometheus.MustRegister(KafkaConsumerPartitionCurrentOffset)
 	prometheus.MustRegister(KafkaConsumerPartitionMaxOffset)
 	prometheus.MustRegister(KafkaConsumerTotalLag)

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -45,6 +45,13 @@ var (
 		},
 		[]string{"cluster", "topic", "partition"},
 	)
+	KafkaConsumerPartitionStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kafka_burrow_partition_status",
+			Help: "The latest status on a topic's partition delivered in label as reported by burrow.",
+		},
+		[]string{"cluster", "topic", "partition", "status"},
+	)
 )
 
 func init() {

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -8,28 +8,28 @@ var (
 			Name: "kafka_burrow_partition_lag",
 			Help: "The lag of the consumer on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition", "status"},
+		[]string{"cluster", "group", "topic", "partition"},
 	)
 	KafkaConsumerPartitionLastOffsetLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_last_offset_lag",
 			Help: "The lag of the latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition", "status"},
+		[]string{"cluster", "group", "topic", "partition"},
 	)
 	KafkaConsumerPartitionCurrentOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_current_offset",
 			Help: "The latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition", "status"},
+		[]string{"cluster", "group", "topic", "partition"},
 	)
 	KafkaConsumerPartitionMaxOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_max_offset",
 			Help: "The log end offset on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition", "status"},
+		[]string{"cluster", "group", "topic", "partition"},
 	)
 	KafkaConsumerTotalLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/burrow_exporter/metrics.go
+++ b/burrow_exporter/metrics.go
@@ -22,14 +22,14 @@ var (
 			Name: "kafka_burrow_partition_current_offset",
 			Help: "The latest offset commit on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "status"},
 	)
 	KafkaConsumerPartitionMaxOffset = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kafka_burrow_partition_max_offset",
 			Help: "The log end offset on a partition as reported by burrow.",
 		},
-		[]string{"cluster", "group", "topic", "partition"},
+		[]string{"cluster", "group", "topic", "partition", "status"},
 	)
 	KafkaConsumerTotalLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
The current partition lag is necessary for checking its growing